### PR TITLE
Migrate sauna detail URLs from query params to path-based format

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -94,7 +94,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   );
 
   const saunaDetailPages: MetadataRoute.Sitemap = saunas.map((sauna) => ({
-    url: `${baseUrl}/tools/saunas?sauna=${sauna.slug}`,
+    url: `${baseUrl}/tools/saunas/s/${sauna.slug}`,
     lastModified: new Date(sauna.updatedAt),
     changeFrequency: "monthly" as const,
     priority: 0.7,

--- a/app/tools/saunas/[location]/page.tsx
+++ b/app/tools/saunas/[location]/page.tsx
@@ -37,11 +37,11 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
         openGraph: {
           title,
           description,
-          url: `https://goleary.com/tools/saunas/${location.slug}?sauna=${sauna.slug}`,
+          url: `https://goleary.com/tools/saunas/${location.slug}/s/${sauna.slug}`,
           type: "website",
         },
         alternates: {
-          canonical: `https://goleary.com/tools/saunas/${location.slug}?sauna=${sauna.slug}`,
+          canonical: `https://goleary.com/tools/saunas/${location.slug}/s/${sauna.slug}`,
         },
       };
     }
@@ -73,7 +73,7 @@ function generateItemListSchema(locationName: string, locationSlug: string) {
     itemListElement: saunas.map((sauna, index) => ({
       "@type": "ListItem",
       position: index + 1,
-      url: `https://goleary.com/tools/saunas/${locationSlug}?sauna=${sauna.slug}`,
+      url: `https://goleary.com/tools/saunas/${locationSlug}/s/${sauna.slug}`,
       name: sauna.name,
     })),
   };

--- a/app/tools/saunas/components/SaunaTable.tsx
+++ b/app/tools/saunas/components/SaunaTable.tsx
@@ -139,7 +139,7 @@ export function SaunaTable({ saunas, compact = false, onSaunaClick, selectedSlug
             <TableRow key={sauna.slug}>
               <TableCell className="sticky left-0 bg-background font-medium">
                 <Link
-                  href={`/tools/saunas?sauna=${sauna.slug}`}
+                  href={`/tools/saunas/s/${sauna.slug}`}
                   className="text-primary hover:underline"
                 >
                   {sauna.name}

--- a/app/tools/saunas/page.tsx
+++ b/app/tools/saunas/page.tsx
@@ -23,11 +23,11 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
         openGraph: {
           title,
           description,
-          url: `https://goleary.com/tools/saunas?sauna=${sauna.slug}`,
+          url: `https://goleary.com/tools/saunas/s/${sauna.slug}`,
           type: "website",
         },
         alternates: {
-          canonical: `https://goleary.com/tools/saunas?sauna=${sauna.slug}`,
+          canonical: `https://goleary.com/tools/saunas/s/${sauna.slug}`,
         },
       };
     }
@@ -61,7 +61,7 @@ function generateItemListSchema() {
     itemListElement: saunas.map((sauna, index) => ({
       "@type": "ListItem",
       position: index + 1,
-      url: `https://goleary.com/tools/saunas?sauna=${sauna.slug}`,
+      url: `https://goleary.com/tools/saunas/s/${sauna.slug}`,
       name: sauna.name,
     })),
   };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -43,6 +43,18 @@ const nextConfig = {
       },
     ];
   },
+  rewrites: async () => {
+    return [
+      {
+        source: "/tools/saunas/s/:slug",
+        destination: "/tools/saunas?sauna=:slug",
+      },
+      {
+        source: "/tools/saunas/:location/s/:slug",
+        destination: "/tools/saunas/:location?sauna=:slug",
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function proxy(request: NextRequest) {
+  const { pathname, searchParams } = request.nextUrl;
+
+  // Redirect old ?sauna= query param URLs to new /s/ path format
+  const saunaSlug = searchParams.get("sauna");
+  if (saunaSlug && pathname.startsWith("/tools/saunas")) {
+    // Don't redirect if already using /s/ path format
+    if (!pathname.includes("/s/")) {
+      const url = request.nextUrl.clone();
+      url.searchParams.delete("sauna");
+      url.pathname = `${pathname}/s/${saunaSlug}`;
+      return NextResponse.redirect(url, 301);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/tools/saunas/:path*",
+};


### PR DESCRIPTION
## Summary

- Replaces `?sauna=<slug>` query parameter URLs with `/s/<slug>` path segments for cleaner, more SEO-friendly sauna detail URLs
- Adds Next.js rewrites to map the new path format back to query params for SSR compatibility
- Switches client-side navigation from Next.js router to `window.history.pushState` to avoid full page reloads, and persists filter state in URL query params
- Adds a middleware proxy (`proxy.ts`) to 301-redirect legacy `?sauna=` URLs to the new path format

## Files changed

- `next.config.mjs` — new rewrite rules for `/s/:slug` paths
- `proxy.ts` — middleware to redirect old query param URLs
- `app/tools/saunas/components/SaunasClient.tsx` — client-side navigation and filter URL sync
- `app/tools/saunas/components/SaunaTable.tsx` — updated link hrefs
- `app/tools/saunas/page.tsx` — updated metadata/canonical URLs
- `app/tools/saunas/[location]/page.tsx` — updated metadata/canonical URLs
- `app/sitemap.ts` — updated sitemap URLs

## Test plan

- [ ] Verify `/tools/saunas/s/<slug>` loads the correct sauna detail
- [ ] Verify `/tools/saunas/<location>/s/<slug>` loads correctly
- [ ] Verify old `?sauna=<slug>` URLs redirect (301) to the new format
- [ ] Verify filter toggles persist in the URL and survive page refresh
- [ ] Verify browser back/forward navigation works for sauna selection
- [ ] Verify sitemap and OpenGraph/canonical URLs use the new format


Made with [Cursor](https://cursor.com)