### PR TITLE
Add FareHarbor as configurable booking provider

### DIFF
--- a/app/api/saunas/availability/route.ts
+++ b/app/api/saunas/availability/route.ts
@@ -16,7 +16,7 @@ export interface AvailabilitySlot {
 export interface AppointmentTypeAvailability {
   appointmentTypeId: string;
   name: string;
-  price: number;
+  price?: number;
   durationMinutes: number;
   private?: boolean;
   seats?: number;
@@ -405,7 +405,7 @@ async function fetchFareHarborAvailability(
   let itemsToFetch: Array<{
     pk: number;
     name: string;
-    price: number;
+    price?: number;
     durationMinutes: number;
     private?: boolean;
     seats?: number;
@@ -421,7 +421,7 @@ async function fetchFareHarborAvailability(
       return {
         pk: configured.itemPk,
         name: configured.name ?? apiItem?.name ?? `Item ${configured.itemPk}`,
-        price: configured.price ?? parsed.price ?? 0,
+        price: configured.price ?? parsed.price ?? undefined,
         durationMinutes:
           configured.durationMinutes ?? parsed.durationMinutes ?? 60,
         private: configured.private,
@@ -445,7 +445,7 @@ async function fetchFareHarborAvailability(
         return {
           pk: item.pk,
           name: item.name,
-          price: parsed.price ?? 0,
+          price: parsed.price ?? undefined,
           durationMinutes: parsed.durationMinutes ?? 60,
         };
       });

--- a/app/tools/debug-saunas/ProviderHealth.tsx
+++ b/app/tools/debug-saunas/ProviderHealth.tsx
@@ -1,6 +1,21 @@
 "use client";
 
+import { TimeSlotBadge } from "@/app/tools/saunas/components/TimeSlotBadge";
 import { useCallback, useEffect, useState } from "react";
+
+interface SlotData {
+  time: string;
+  slotsAvailable: number | null;
+}
+
+interface TypeData {
+  name: string;
+  price?: number;
+  durationMinutes: number;
+  private?: boolean;
+  seats?: number;
+  dates: Record<string, SlotData[]>;
+}
 
 interface HealthResult {
   slug: string;
@@ -9,6 +24,7 @@ interface HealthResult {
   slotCount?: number;
   appointmentTypes?: number;
   error?: string;
+  data?: TypeData[];
 }
 
 export interface PlatformSauna {
@@ -33,6 +49,7 @@ export default function ProviderHealth({
   const [results, setResults] = useState<Map<string, HealthResult>>(new Map());
   const [running, setRunning] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [expandedSaunas, setExpandedSaunas] = useState<Set<string>>(new Set());
 
   const today = new Date().toISOString().split("T")[0];
 
@@ -45,6 +62,15 @@ export default function ProviderHealth({
       const next = new Set(prev);
       if (next.has(platform)) next.delete(platform);
       else next.add(platform);
+      return next;
+    });
+  };
+
+  const toggleSauna = (slug: string) => {
+    setExpandedSaunas((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
       return next;
     });
   };
@@ -102,6 +128,7 @@ export default function ProviderHealth({
             responseMs: elapsed,
             slotCount,
             appointmentTypes: types.length,
+            data: types,
           });
           return next;
         });
@@ -214,6 +241,8 @@ export default function ProviderHealth({
                 isExpanded={isExpanded}
                 onToggle={() => toggle(p.platform)}
                 results={results}
+                expandedSaunas={expandedSaunas}
+                onToggleSauna={toggleSauna}
               />
             );
           })}
@@ -221,6 +250,26 @@ export default function ProviderHealth({
       </table>
     </section>
   );
+}
+
+const toggleColorClass: Record<string, string> = {
+  ok: "text-green-600",
+  warn: "text-amber-500",
+  error: "text-red-600",
+  pending: "text-gray-400 animate-pulse",
+};
+
+function platformToggleColor(
+  configured: number,
+  done: boolean,
+  errors: number,
+  warns: number
+): string {
+  if (configured === 0) return "text-gray-400";
+  if (!done) return "text-gray-400 animate-pulse";
+  if (errors > 0) return "text-red-600";
+  if (warns > 0) return "text-amber-500";
+  return "text-green-600";
 }
 
 function PlatformRow({
@@ -233,6 +282,8 @@ function PlatformRow({
   isExpanded,
   onToggle,
   results,
+  expandedSaunas,
+  onToggleSauna,
 }: {
   platform: PlatformGroup;
   configured: number;
@@ -243,7 +294,11 @@ function PlatformRow({
   isExpanded: boolean;
   onToggle: () => void;
   results: Map<string, HealthResult>;
+  expandedSaunas: Set<string>;
+  onToggleSauna: (slug: string) => void;
 }) {
+  const arrowColor = platformToggleColor(configured, done, errors, warns);
+
   return (
     <>
       <tr
@@ -251,7 +306,7 @@ function PlatformRow({
         onClick={onToggle}
       >
         <td className="py-2 pr-4 font-mono">
-          <span className="inline-block w-4 text-gray-400 text-xs">
+          <span className={`inline-block w-4 text-xs ${arrowColor}`}>
             {isExpanded ? "▼" : "▶"}
           </span>
           {platform.platform}
@@ -289,44 +344,149 @@ function PlatformRow({
       {isExpanded &&
         platform.saunas.map((s) => {
           const r = results.get(s.slug);
+          const saunaExpanded = expandedSaunas.has(s.slug);
+          const saunaArrowColor = s.providerType
+            ? (toggleColorClass[r?.status ?? ""] ?? "text-gray-400")
+            : "text-gray-300";
+
           return (
-            <tr key={s.slug} className="border-b bg-gray-50/50">
-              <td className="py-1.5 pr-4 pl-8 text-xs" colSpan={s.providerType ? 1 : 4}>
-                <StatusDot status={r?.status ?? null} />
-                <a
-                  href={`/tools/saunas?sauna=${encodeURIComponent(s.slug)}`}
-                  className="ml-2 hover:text-blue-600 hover:underline"
-                >
-                  {s.name}
-                </a>
-                {!s.providerType && (
-                  <span className="ml-2 text-gray-400">not configured</span>
-                )}
-              </td>
-              {s.providerType && (
-                <>
-                  <td className="py-1.5 pr-4 text-right font-mono text-xs text-gray-500">
-                    {r?.responseMs != null ? `${r.responseMs}ms` : "—"}
-                  </td>
-                  <td className="py-1.5 pr-4 text-right text-xs text-gray-500">
-                    {r?.appointmentTypes != null
-                      ? `${r.appointmentTypes} types`
-                      : "—"}
-                  </td>
-                  <td className="py-1.5 pr-4 text-right text-xs text-gray-500">
-                    {r?.slotCount != null ? `${r.slotCount} slots` : "—"}
-                    {r?.error && (
-                      <span className="ml-2 text-red-600 truncate max-w-xs inline-block align-bottom">
-                        {r.error}
-                      </span>
-                    )}
-                  </td>
-                </>
-              )}
-            </tr>
+            <SaunaRow
+              key={s.slug}
+              sauna={s}
+              result={r}
+              isExpanded={saunaExpanded}
+              arrowColor={saunaArrowColor}
+              onToggle={() => s.providerType && onToggleSauna(s.slug)}
+            />
           );
         })}
     </>
+  );
+}
+
+function SaunaRow({
+  sauna,
+  result,
+  isExpanded,
+  arrowColor,
+  onToggle,
+}: {
+  sauna: PlatformSauna;
+  result: HealthResult | undefined;
+  isExpanded: boolean;
+  arrowColor: string;
+  onToggle: () => void;
+}) {
+  return (
+    <>
+      <tr
+        className={`border-b bg-gray-50/50 ${sauna.providerType ? "cursor-pointer hover:bg-gray-100/50" : ""}`}
+        onClick={onToggle}
+      >
+        <td className="py-1.5 pr-4 pl-6 text-xs" colSpan={sauna.providerType ? 1 : 4}>
+          {sauna.providerType && (
+            <span className={`inline-block w-4 text-xs ${arrowColor}`}>
+              {isExpanded ? "▼" : "▶"}
+            </span>
+          )}
+          {!sauna.providerType && <span className="inline-block w-4" />}
+          <StatusDot status={result?.status ?? null} />
+          <a
+            href={`/tools/saunas?sauna=${encodeURIComponent(sauna.slug)}`}
+            className="ml-2 hover:text-blue-600 hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {sauna.name}
+          </a>
+          {!sauna.providerType && (
+            <span className="ml-2 text-gray-400">not configured</span>
+          )}
+        </td>
+        {sauna.providerType && (
+          <>
+            <td className="py-1.5 pr-4 text-right font-mono text-xs text-gray-500">
+              {result?.responseMs != null ? `${result.responseMs}ms` : "—"}
+            </td>
+            <td className="py-1.5 pr-4 text-right text-xs text-gray-500">
+              {result?.appointmentTypes != null
+                ? `${result.appointmentTypes} types`
+                : "—"}
+            </td>
+            <td className="py-1.5 pr-4 text-right text-xs text-gray-500">
+              {result?.slotCount != null ? `${result.slotCount} slots` : "—"}
+              {result?.error && (
+                <span className="ml-2 text-red-600 truncate max-w-xs inline-block align-bottom">
+                  {result.error}
+                </span>
+              )}
+            </td>
+          </>
+        )}
+      </tr>
+      {isExpanded && result?.data && (
+        <tr className="border-b bg-gray-100/50">
+          <td colSpan={4} className="py-2 pl-14 pr-4">
+            <SlotDetails types={result.data} />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function SlotDetails({ types }: { types: TypeData[] }) {
+  if (types.length === 0) {
+    return <p className="text-xs text-gray-400 italic">No appointment types returned</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {types.map((t, i) => {
+        const allDates = Object.keys(t.dates).sort();
+        const totalSlots = allDates.reduce(
+          (sum, d) => sum + t.dates[d].length,
+          0
+        );
+
+        return (
+          <div key={i} className="text-xs">
+            <div className="font-medium text-gray-700 mb-1">
+              {t.name}
+              <span className="ml-2 font-normal text-gray-400">
+                {t.price != null && `$${t.price} / `}{t.durationMinutes}min
+                {t.private && " / private"}
+                {t.seats && ` / ${t.seats} seats`}
+                {" — "}
+                {totalSlots} slot{totalSlots !== 1 ? "s" : ""}
+              </span>
+            </div>
+            {allDates.length === 0 ? (
+              <p className="text-gray-400 italic pl-2">No dates with availability</p>
+            ) : (
+              <div className="pl-2 space-y-1">
+                {allDates.map((date) => (
+                  <div key={date} className="flex gap-2 items-start">
+                    <span className="text-gray-500 font-mono w-20 shrink-0 pt-0.5">
+                      {date}
+                    </span>
+                    <div className="flex flex-wrap gap-1.5">
+                      {t.dates[date].map((slot, j) => (
+                        <TimeSlotBadge
+                          key={j}
+                          time={slot.time}
+                          slotsAvailable={slot.slotsAvailable}
+                          className="text-xs gap-1"
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
   );
 }
 

--- a/app/tools/saunas/components/SaunaAvailability.tsx
+++ b/app/tools/saunas/components/SaunaAvailability.tsx
@@ -254,7 +254,7 @@ export function SaunaAvailability({ sauna, onHasAvailability, onFirstAvailableDa
                         )}
                       </p>
                       <span className="text-xs text-muted-foreground shrink-0 whitespace-nowrap">
-                        ${appointmentType.price} / {appointmentType.durationMinutes}min
+                        {appointmentType.price != null && `$${appointmentType.price} / `}{appointmentType.durationMinutes}min
                       </span>
                     </div>
                   )}

--- a/data/saunas/saunas.ts
+++ b/data/saunas/saunas.ts
@@ -4283,8 +4283,8 @@ export const saunas: Sauna[] = [
       timezone: "America/New_York",
       items: [
         { itemPk: 688205, name: "Single Session", price: 39, durationMinutes: 60 },
-        { itemPk: 627902, name: "Private Rental: 8 Seater", private: true, seats: 8 },
-        { itemPk: 636095, name: "Private Rental: 12 Seater", private: true, seats: 12 },
+        { itemPk: 627902, name: "Private Rental: 8 Seater", price: 742, private: true, seats: 8 },
+        { itemPk: 636095, name: "Private Rental: 12 Seater", price: 1166, private: true, seats: 12 },
       ],
     },
     sessionPrice: 39,


### PR DESCRIPTION
## Summary
- Adds FareHarbor as a new booking provider using their public API (`fareharbor.com/api/v1/`), matching the existing Acuity/Wix/Glofox pattern
- Auto-discovers bookable items (filters out gift cards, memberships, session packs via `is_retail`), with support for explicit item lists when needed
- Configures 6 existing FareHarbor saunas: Cedar & Stone, NYUBU, Remote Floating Sauna (Tofino), DRYYP, and both HUHT locations
- Adds `warn` status (amber) to the debug health dashboard for providers returning 0 types or 0 slots

## Test plan
- [x] `next build` passes with no TypeScript errors
- [x] Tested API endpoint for DRYYP — returns community session with slot counts
- [x] Tested API endpoint for Cedar & Stone — auto-discovers 3 session types with prices/durations parsed from headlines
- [x] Verify debug page shows amber dots for 0-slot providers (e.g. NYUBU, HUHT)
- [ ] Verify availability UI renders correctly for FareHarbor saunas

🤖 Generated with [Claude Code](https://claude.com/claude-code)