### PR TITLE
Add guest count filter to availability

### DIFF
--- a/app/tools/saunas/components/SaunaDetailPanel.tsx
+++ b/app/tools/saunas/components/SaunaDetailPanel.tsx
@@ -24,6 +24,8 @@ interface SaunaDetailPanelProps {
   sauna: Sauna;
   availabilityDate?: string | null;
   onAvailabilityDateChange?: (date: string | null) => void;
+  guests?: number | null;
+  onGuestsChange?: (guests: number) => void;
 }
 
 function AmenityBadge({
@@ -48,7 +50,7 @@ function AmenityBadge({
   );
 }
 
-export function SaunaDetailPanel({ sauna, availabilityDate, onAvailabilityDateChange }: SaunaDetailPanelProps) {
+export function SaunaDetailPanel({ sauna, availabilityDate, onAvailabilityDateChange, guests, onGuestsChange }: SaunaDetailPanelProps) {
   const [hasAvailability, setHasAvailability] = useState(false);
   const [firstAvailableDate, setFirstAvailableDate] = useState<string | null>(null);
   const [lastAvailableDate, setLastAvailableDate] = useState<string | null>(null);
@@ -138,7 +140,7 @@ export function SaunaDetailPanel({ sauna, availabilityDate, onAvailabilityDateCh
         </div>
 
         {/* Availability */}
-        <SaunaAvailability sauna={sauna} availabilityDate={availabilityDate} onAvailabilityDateChange={onAvailabilityDateChange} onHasAvailability={handleHasAvailability} onFirstAvailableDate={handleFirstAvailableDate} onLastAvailableDate={handleLastAvailableDate} onTideTimeClick={handleTideTimeClick} />
+        <SaunaAvailability sauna={sauna} availabilityDate={availabilityDate} onAvailabilityDateChange={onAvailabilityDateChange} guests={guests} onGuestsChange={onGuestsChange} onHasAvailability={handleHasAvailability} onFirstAvailableDate={handleFirstAvailableDate} onLastAvailableDate={handleLastAvailableDate} onTideTimeClick={handleTideTimeClick} />
 
         {/* Tides */}
         <SaunaTides sauna={sauna} date={firstAvailableDate} endDate={lastAvailableDate} waitForDate={!!sauna.bookingProvider} open={tideOpen} onOpenChange={setTideOpen} highlightTime={tideHighlightTime} highlightColor={tideHighlightColor} scrollNonce={tideScrollNonce} />

--- a/app/tools/saunas/components/SaunaFilters.tsx
+++ b/app/tools/saunas/components/SaunaFilters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { CalendarIcon, Loader2, RefreshCw } from "lucide-react";
+import { CalendarIcon, Loader2, Minus, Plus, User, Users } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -35,6 +35,7 @@ export interface FilterState {
   waterfrontOnly: boolean;
   naturalPlungeOnly: boolean;
   availabilityDate: string | null;
+  guests: number | null;
 }
 
 interface SaunaFiltersProps {
@@ -51,6 +52,7 @@ export function getDefaultFilters(): FilterState {
     waterfrontOnly: false,
     naturalPlungeOnly: false,
     availabilityDate: null,
+    guests: null,
   };
 }
 
@@ -114,6 +116,7 @@ export function SaunaFilters({
       onFiltersChange({
         ...filters,
         availabilityDate: checked ? defaultDate : null,
+        guests: checked ? filters.guests : null,
       });
     },
     [filters, onFiltersChange, defaultDate]
@@ -184,20 +187,20 @@ export function SaunaFilters({
       {showAvailabilityFilter && (
         <>
           <Separator />
-          <div className="flex items-center gap-3">
+          <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-2">
               <Checkbox
                 id="availability"
                 checked={filters.availabilityDate !== null}
                 onCheckedChange={(v) => handleAvailabilityToggle(v === true)}
               />
-              <Label htmlFor="availability" className="text-sm cursor-pointer">
-                Has Availability
+              <Label htmlFor="availability" className="text-sm cursor-pointer whitespace-nowrap">
+                {filters.availabilityDate !== null ? "Available" : "Has Availability"}
               </Label>
             </div>
 
             {filters.availabilityDate !== null && (
-              <>
+              <div className="flex items-center gap-1.5">
                 <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
                   <PopoverTrigger asChild>
                     <Button
@@ -205,7 +208,11 @@ export function SaunaFilters({
                       size="sm"
                       className="h-7 gap-1.5 text-xs"
                     >
-                      <CalendarIcon className="h-3 w-3" />
+                      {availabilityLoading ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <CalendarIcon className="h-3 w-3" />
+                      )}
                       {formatDateButton(filters.availabilityDate)}
                     </Button>
                   </PopoverTrigger>
@@ -220,10 +227,62 @@ export function SaunaFilters({
                   </PopoverContent>
                 </Popover>
 
-                {availabilityLoading && (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-                )}
-              </>
+                {/* Desktop: select dropdown */}
+                <div className="hidden lg:flex items-center gap-1.5">
+                  {(filters.guests ?? 1) > 1 ? <Users className="h-3 w-3 text-muted-foreground" /> : <User className="h-3 w-3 text-muted-foreground" />}
+                  <select
+                    value={filters.guests ?? 1}
+                    onChange={(e) =>
+                      onFiltersChange({
+                        ...filters,
+                        guests: parseInt(e.target.value, 10),
+                      })
+                    }
+                    className="h-7 rounded-md border border-input bg-background px-2 text-xs"
+                  >
+                    {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+                      <option key={n} value={n}>
+                        {n}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Mobile: +/- stepper */}
+                <div className="flex lg:hidden items-center gap-1.5">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={() =>
+                      onFiltersChange({
+                        ...filters,
+                        guests: Math.max(1, (filters.guests ?? 2) - 1),
+                      })
+                    }
+                  >
+                    <Minus className="h-3 w-3" />
+                  </Button>
+                  {(filters.guests ?? 1) > 1 ? <Users className="h-3 w-3 text-muted-foreground" /> : <User className="h-3 w-3 text-muted-foreground" />}
+                  <span className="text-xs w-3 text-center tabular-nums">
+                    {filters.guests ?? 1}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={() =>
+                      onFiltersChange({
+                        ...filters,
+                        guests: Math.min(10, (filters.guests ?? 1) + 1),
+                      })
+                    }
+                  >
+                    <Plus className="h-3 w-3" />
+                  </Button>
+                </div>
+
+              </div>
             )}
           </div>
         </>


### PR DESCRIPTION
## Summary
- Adds a guest count selector to the availability filter (select dropdown on desktop, +/- stepper on mobile) and detail view
- Filters slots by capacity: shared sessions by `slotsAvailable`, private sessions by `seats`
- Caches raw API responses client-side so changing guest count re-filters instantly without re-fetching
- Persists guest count in URL (`?guests=N`), synced with browser back/forward
- Shows clear (X) button when date or guests are non-default; resets both on click
- Uses single-person icon when guests=1, multi-person icon when >1

## Test plan
- [ ] Toggle availability filter, verify guest selector appears
- [ ] Change guest count on desktop (select) and mobile (+/- stepper)
- [ ] Verify slots filter correctly by capacity
- [ ] Check URL updates with `?guests=N` param
- [ ] Open detail view, verify guest picker syncs with list filter
- [ ] Click X to clear — both date and guests should reset
- [ ] Browser back/forward preserves guest count

🤖 Generated with [Claude Code](https://claude.com/claude-code)