### PR TITLE
Add password-protected login and private section

### DIFF
--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { createHmac } from "crypto";
+
+const COOKIE_NAME = "auth-token";
+
+function getSecret(): string {
+  return process.env.AUTH_SECRET || process.env.AUTH_PASSWORD || "fallback";
+}
+
+function computeToken(): string {
+  const hmac = createHmac("sha256", getSecret());
+  hmac.update("authenticated");
+  return hmac.digest("hex");
+}
+
+export async function login(
+  _prevState: { error?: string },
+  formData: FormData
+): Promise<{ error?: string }> {
+  const password = formData.get("password") as string;
+  const expected = process.env.AUTH_PASSWORD;
+
+  if (!expected) {
+    return { error: "AUTH_PASSWORD environment variable is not set." };
+  }
+
+  if (password !== expected) {
+    return { error: "Incorrect password." };
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set(COOKIE_NAME, computeToken(), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30, // 30 days
+  });
+
+  redirect("/private");
+}
+
+export async function logout() {
+  const cookieStore = await cookies();
+  cookieStore.delete(COOKIE_NAME);
+  redirect("/login");
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useActionState } from "react";
+import { login } from "./actions";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+export default function LoginPage() {
+  const [state, formAction, pending] = useActionState(login, {});
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Login</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form action={formAction} className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                name="password"
+                type="password"
+                required
+                autoFocus
+              />
+            </div>
+            {state.error && (
+              <p className="text-sm text-red-600">{state.error}</p>
+            )}
+            <Button type="submit" disabled={pending}>
+              {pending ? "Logging in..." : "Login"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/private/page.tsx
+++ b/app/private/page.tsx
@@ -1,0 +1,16 @@
+import { Button } from "@/components/ui/button";
+import { logout } from "@/app/login/actions";
+
+export default function PrivatePage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-4">
+      <h1 className="text-2xl font-bold">Private Area</h1>
+      <p className="text-muted-foreground">
+        You are logged in. This content is password-protected.
+      </p>
+      <form action={logout}>
+        <Button variant="outline">Logout</Button>
+      </form>
+    </div>
+  );
+}

--- a/components/root-layout.tsx
+++ b/components/root-layout.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { isAuthenticated } from "@/lib/auth";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -6,11 +7,12 @@ import {
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const loggedIn = await isAuthenticated();
   // Create any shared layout or styles here
   return (
     <div className="max-w-2xl m-auto text-md py-6 flex flex-col gap-4 items-center">
@@ -69,7 +71,7 @@ export default function RootLayout({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        {process.env.NODE_ENV === "development" && (
+        {(process.env.NODE_ENV === "development" || loggedIn) && (
           <DropdownMenu>
             <DropdownMenuTrigger>Debug</DropdownMenuTrigger>
             <DropdownMenuContent>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,19 @@
+import { cookies } from "next/headers";
+import { createHmac } from "crypto";
+
+function getSecret(): string {
+  return process.env.AUTH_SECRET || process.env.AUTH_PASSWORD || "fallback";
+}
+
+function computeToken(): string {
+  const hmac = createHmac("sha256", getSecret());
+  hmac.update("authenticated");
+  return hmac.digest("hex");
+}
+
+export async function isAuthenticated(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("auth-token")?.value;
+  if (!token) return false;
+  return token === computeToken();
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+
+async function computeToken(secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode("authenticated")
+  );
+  return Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function middleware(request: NextRequest) {
+  const token = request.cookies.get("auth-token")?.value;
+  if (!token) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  const secret =
+    process.env.AUTH_SECRET || process.env.AUTH_PASSWORD || "fallback";
+  const expected = await computeToken(secret);
+
+  if (token !== expected) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/private/:path*"],
+};


### PR DESCRIPTION
## Summary
- Adds `/login` page with shared-password authentication
- Adds `/private` protected section gated by Next.js middleware
- Shows debug menu in nav when logged in (not just in dev mode)
- Auth uses HMAC-signed HttpOnly cookie, password set via `AUTH_PASSWORD` env var

## Test plan
- [ ] Visit `/private` without logging in — should redirect to `/login`
- [ ] Enter wrong password — should show error
- [ ] Enter correct password — should redirect to `/private`
- [ ] Verify debug menu appears in nav after login
- [ ] Click logout — should redirect to `/login` and block `/private`

🤖 Generated with [Claude Code](https://claude.com/claude-code)