### PR TITLE
?? Persist availability date filter and enable date picker

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "next-devtools": {
+      "command": "npx",
+      "args": ["-y", "next-devtools-mcp@latest"]
+    }
+  }
+}

--- a/app/tools/saunas/components/SaunaAvailability.tsx
+++ b/app/tools/saunas/components/SaunaAvailability.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { type Sauna } from "@/data/saunas/saunas";
 import type {
   AvailabilityResponse,
@@ -8,14 +8,21 @@ import type {
 } from "@/app/api/saunas/availability/route";
 import type { TideDataPoint, TidesResponse } from "@/app/api/saunas/tides/route";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ArrowUpRight, Minus, ArrowDownRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { ArrowUpRight, Minus, ArrowDownRight, CalendarIcon, X, Loader2 } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
 import { getTideLevelForSlot, type TideLevel } from "./tideUtils";
 import { TimeSlotBadge } from "./TimeSlotBadge";
 
 
+const DEFAULT_MAX_DAYS = 3;
+
 interface SaunaAvailabilityProps {
   sauna: Sauna;
+  availabilityDate?: string | null;
+  onAvailabilityDateChange?: (date: string | null) => void;
   onHasAvailability?: (hasAvailability: boolean) => void;
   onFirstAvailableDate?: (date: string | null) => void;
   onLastAvailableDate?: (date: string | null) => void;
@@ -40,6 +47,21 @@ function formatDateLabel(dateStr: string): string {
 
   return date.toLocaleDateString("en-US", {
     weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatDateButton(dateStr: string): string {
+  const date = new Date(dateStr + "T00:00:00");
+  const today = new Date();
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  if (dateStr === localDateStr(today)) return "Today";
+  if (dateStr === localDateStr(tomorrow)) return "Tomorrow";
+
+  return date.toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
   });
@@ -104,21 +126,50 @@ const TIDE_LEVEL_COLORS: Record<TideLevel, string> = {
   low: "rgb(252, 165, 165)",   // red-300
 };
 
-export function SaunaAvailability({ sauna, onHasAvailability, onFirstAvailableDate, onLastAvailableDate, onTideTimeClick }: SaunaAvailabilityProps) {
+export function SaunaAvailability({ sauna, availabilityDate, onAvailabilityDateChange, onHasAvailability, onFirstAvailableDate, onLastAvailableDate, onTideTimeClick }: SaunaAvailabilityProps) {
   const [data, setData] = useState<AvailabilityResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [tideDataByDate, setTideDataByDate] = useState<Record<string, TideDataPoint[]>>({});
+  const [calendarOpen, setCalendarOpen] = useState(false);
+
+  const today = new Date();
+
+  const handleDateSelect = useCallback(
+    (date: Date | undefined) => {
+      if (date) {
+        onAvailabilityDateChange?.(localDateStr(date));
+        setCalendarOpen(false);
+      }
+    },
+    [onAvailabilityDateChange]
+  );
+
+  const selectedCalendarDate = availabilityDate
+    ? new Date(availabilityDate + "T00:00:00")
+    : undefined;
+
+  // Track whether we're refreshing (have stale data) vs initial loading (no data yet)
+  const [refreshing, setRefreshing] = useState(false);
+  const prevSlugRef = useRef(sauna.slug);
 
   useEffect(() => {
     if (!sauna.bookingProvider) return;
 
-    setData(null);
-    setTideDataByDate({});
-    setLoading(true);
+    // Clear data and show skeletons when switching saunas; keep stale data when changing dates
+    const isNewSauna = prevSlugRef.current !== sauna.slug;
+    prevSlugRef.current = sauna.slug;
+    if (isNewSauna || !data) {
+      setData(null);
+      setTideDataByDate({});
+      setLoading(true);
+      setRefreshing(false);
+    } else {
+      setRefreshing(true);
+    }
     setError(null);
 
-    const startDate = localDateStr(new Date());
+    const startDate = availabilityDate || localDateStr(new Date());
     fetch(
       `/api/saunas/availability?slug=${encodeURIComponent(sauna.slug)}&startDate=${startDate}`
     )
@@ -128,13 +179,17 @@ export function SaunaAvailability({ sauna, onHasAvailability, onFirstAvailableDa
       })
       .then((json: AvailabilityResponse) => {
         setData(json);
+        setTideDataByDate({});
         setLoading(false);
+        setRefreshing(false);
       })
       .catch((err) => {
         setError(err.message);
         setLoading(false);
+        setRefreshing(false);
       });
-  }, [sauna.slug, sauna.bookingProvider]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sauna.slug, sauna.bookingProvider, availabilityDate]);
 
   useEffect(() => {
     if (loading) return;
@@ -210,10 +265,16 @@ export function SaunaAvailability({ sauna, onHasAvailability, onFirstAvailableDa
   }
 
   const byDate = data ? groupByDate(data.appointmentTypes) : {};
-  const sortedDates = Object.keys(byDate).sort();
+  const allSortedDates = Object.keys(byDate).sort();
   const isSingleType = data ? data.appointmentTypes.length <= 1 : false;
 
-  if (!data || sortedDates.length === 0) {
+  // Filter displayed dates: specific date when set, otherwise limit to DEFAULT_MAX_DAYS
+  const displayDates = availabilityDate
+    ? allSortedDates.filter((d) => d === availabilityDate)
+    : allSortedDates.slice(0, DEFAULT_MAX_DAYS);
+  const hasMoreDates = !availabilityDate && allSortedDates.length > displayDates.length;
+
+  if (!data || allSortedDates.length === 0) {
     return (
       <div>
         <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">
@@ -226,13 +287,67 @@ export function SaunaAvailability({ sauna, onHasAvailability, onFirstAvailableDa
     );
   }
 
+  const datePicker = onAvailabilityDateChange ? (
+    <div className="flex items-center gap-1">
+      <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm" className="h-6 gap-1.5 text-xs">
+            {refreshing ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <CalendarIcon className="h-3 w-3" />
+            )}
+            {availabilityDate ? formatDateButton(availabilityDate) : "Pick date"}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="single"
+            selected={selectedCalendarDate}
+            onSelect={handleDateSelect}
+            disabled={{ before: today }}
+            defaultMonth={selectedCalendarDate}
+          />
+        </PopoverContent>
+      </Popover>
+      {availabilityDate && (
+        <button
+          type="button"
+          onClick={() => onAvailabilityDateChange(null)}
+          className="h-6 w-6 inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+  ) : null;
+
+  if (displayDates.length === 0) {
+    return (
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <p className="text-xs text-muted-foreground uppercase tracking-wide">
+            Availability
+          </p>
+          {datePicker}
+        </div>
+        <p className="text-sm text-muted-foreground">
+          No availability on this date
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <p className="text-xs text-muted-foreground uppercase tracking-wide mb-2">
-        Upcoming Availability
-      </p>
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs text-muted-foreground uppercase tracking-wide">
+          Upcoming Availability
+        </p>
+        {datePicker}
+      </div>
       <div className="space-y-4">
-        {sortedDates.map((dateStr) => (
+        {displayDates.map((dateStr) => (
           <div key={dateStr}>
             <p className="text-sm font-medium mb-2">
               {formatDateLabel(dateStr)}
@@ -297,6 +412,11 @@ export function SaunaAvailability({ sauna, onHasAvailability, onFirstAvailableDa
             </div>
           </div>
         ))}
+        {hasMoreDates && (
+          <p className="text-xs text-muted-foreground">
+            + {allSortedDates.length - displayDates.length} more day{allSortedDates.length - displayDates.length > 1 ? "s" : ""} available
+          </p>
+        )}
       </div>
     </div>
   );

--- a/app/tools/saunas/components/SaunaDetailPanel.tsx
+++ b/app/tools/saunas/components/SaunaDetailPanel.tsx
@@ -22,6 +22,8 @@ import {
 
 interface SaunaDetailPanelProps {
   sauna: Sauna;
+  availabilityDate?: string | null;
+  onAvailabilityDateChange?: (date: string | null) => void;
 }
 
 function AmenityBadge({
@@ -46,7 +48,7 @@ function AmenityBadge({
   );
 }
 
-export function SaunaDetailPanel({ sauna }: SaunaDetailPanelProps) {
+export function SaunaDetailPanel({ sauna, availabilityDate, onAvailabilityDateChange }: SaunaDetailPanelProps) {
   const [hasAvailability, setHasAvailability] = useState(false);
   const [firstAvailableDate, setFirstAvailableDate] = useState<string | null>(null);
   const [lastAvailableDate, setLastAvailableDate] = useState<string | null>(null);
@@ -136,7 +138,7 @@ export function SaunaDetailPanel({ sauna }: SaunaDetailPanelProps) {
         </div>
 
         {/* Availability */}
-        <SaunaAvailability sauna={sauna} onHasAvailability={handleHasAvailability} onFirstAvailableDate={handleFirstAvailableDate} onLastAvailableDate={handleLastAvailableDate} onTideTimeClick={handleTideTimeClick} />
+        <SaunaAvailability sauna={sauna} availabilityDate={availabilityDate} onAvailabilityDateChange={onAvailabilityDateChange} onHasAvailability={handleHasAvailability} onFirstAvailableDate={handleFirstAvailableDate} onLastAvailableDate={handleLastAvailableDate} onTideTimeClick={handleTideTimeClick} />
 
         {/* Tides */}
         <SaunaTides sauna={sauna} date={firstAvailableDate} endDate={lastAvailableDate} waitForDate={!!sauna.bookingProvider} open={tideOpen} onOpenChange={setTideOpen} highlightTime={tideHighlightTime} highlightColor={tideHighlightColor} scrollNonce={tideScrollNonce} />

--- a/app/tools/saunas/components/SaunasClient.tsx
+++ b/app/tools/saunas/components/SaunasClient.tsx
@@ -71,7 +71,53 @@ function shouldAllowDrag(target: EventTarget | null): boolean {
 export function SaunasClient({ saunas, title, basePath, center, zoom }: SaunasClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [filters, setFilters] = useState<FilterState>(getDefaultFilters());
+  const [filters, setFilters] = useState<FilterState>(() => {
+    const dateParam = searchParams.get("date");
+    const defaults = getDefaultFilters();
+    if (dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam)) {
+      return { ...defaults, availabilityDate: dateParam };
+    }
+    return defaults;
+  });
+
+  // Sync availabilityDate filter to/from URL query params
+  const updateFilters = useCallback((newFilters: FilterState) => {
+    setFilters(newFilters);
+    const params = new URLSearchParams(searchParams.toString());
+    if (newFilters.availabilityDate) {
+      params.set("date", newFilters.availabilityDate);
+    } else {
+      params.delete("date");
+    }
+    const queryString = params.toString();
+    router.replace(queryString ? `${basePath}?${queryString}` : basePath, { scroll: false });
+  }, [searchParams, basePath, router]);
+
+  const handleAvailabilityDateChange = useCallback((date: string | null) => {
+    setFilters((prev) => {
+      const newFilters = { ...prev, availabilityDate: date };
+      const params = new URLSearchParams(searchParams.toString());
+      if (date) {
+        params.set("date", date);
+      } else {
+        params.delete("date");
+      }
+      const queryString = params.toString();
+      router.replace(queryString ? `${basePath}?${queryString}` : basePath, { scroll: false });
+      return newFilters;
+    });
+  }, [searchParams, basePath, router]);
+
+  // Sync URL back to state on browser back/forward
+  useEffect(() => {
+    const dateParam = searchParams.get("date");
+    const newDate = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : null;
+    setFilters((prev) => {
+      if (prev.availabilityDate === newDate) return prev;
+      return { ...prev, availabilityDate: newDate };
+    });
+  }, [searchParams]);
+
   const [sheetHeight, setSheetHeight] = useState(MIN_SHEET_HEIGHT);
   const [isDragging, setIsDragging] = useState(false);
   const [mapBounds, setMapBounds] = useState<LatLngBounds | null>(null);
@@ -96,13 +142,18 @@ export function SaunasClient({ saunas, title, basePath, center, zoom }: SaunasCl
   const handleZoomChange = useCallback((zoom: number) => {
     setCurrentZoom(zoom);
     if (zoom < AVAILABILITY_ZOOM_THRESHOLD) {
-      setFilters((prev) =>
-        prev.availabilityDate !== null
-          ? { ...prev, availabilityDate: null }
-          : prev
-      );
+      setFilters((prev) => {
+        if (prev.availabilityDate === null) return prev;
+        const newFilters = { ...prev, availabilityDate: null };
+        // Also clear date from URL
+        const params = new URLSearchParams(searchParams.toString());
+        params.delete("date");
+        const queryString = params.toString();
+        router.replace(queryString ? `${basePath}?${queryString}` : basePath, { scroll: false });
+        return newFilters;
+      });
     }
-  }, []);
+  }, [searchParams, basePath, router]);
 
   const showAvailabilityFilter = currentZoom >= AVAILABILITY_ZOOM_THRESHOLD;
 
@@ -440,7 +491,7 @@ export function SaunasClient({ saunas, title, basePath, center, zoom }: SaunasCl
       </div>
       <SaunaFilters
         filters={filters}
-        onFiltersChange={setFilters}
+        onFiltersChange={updateFilters}
         showAvailabilityFilter={showAvailabilityFilter}
         availabilityLoading={availabilityLoading}
       />
@@ -478,7 +529,7 @@ export function SaunasClient({ saunas, title, basePath, center, zoom }: SaunasCl
                 Back to list
               </button>
               <div className="flex-1 overflow-hidden">
-                <SaunaDetailPanel sauna={selectedSauna} />
+                <SaunaDetailPanel sauna={selectedSauna} availabilityDate={filters.availabilityDate} onAvailabilityDateChange={handleAvailabilityDateChange} />
               </div>
             </>
           ) : (
@@ -547,7 +598,7 @@ export function SaunasClient({ saunas, title, basePath, center, zoom }: SaunasCl
                   Back to list
                 </button>
                 <div className="flex-1 overflow-auto min-h-0">
-                  <SaunaDetailPanel sauna={selectedSauna} />
+                  <SaunaDetailPanel sauna={selectedSauna} availabilityDate={filters.availabilityDate} onAvailabilityDateChange={handleAvailabilityDateChange} />
                 </div>
               </>
             ) : (


### PR DESCRIPTION
## Summary

- Persist `availabilityDate` in URL query params (`?date=YYYY-MM-DD`) so the filter survives page reload and browser back/forward navigation
- Add interactive date picker to the availability section in sauna detail view, letting users change the date directly from the details panel
- Add clear button (X) to remove the date filter
- Limit detail view availability display to 3 days by default; show only the selected date when one is chosen
- Display loading spinner on date picker button during refresh and keep stale results visible instead of showing skeletons when changing dates
- Set up Next.js MCP support for agent-assisted development

Fixes #25

## Test plan

- [ ] Toggle availability filter on list view, verify `?date=` appears in URL
- [ ] Click into a sauna detail, verify date persists in URL and availability shows for that date
- [ ] Use date picker in detail view to change date, verify URL updates and new availability loads
- [ ] Click X button to clear date, verify URL param is removed
- [ ] Click "Back to list", verify date filter is still active
- [ ] Reload page with `?date=` in URL, verify filter is restored
- [ ] Verify detail view shows max 3 days + "more days available" indicator
- [ ] Switch to different sauna while loading, verify skeletons appear (not stale data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)