### PR TITLE
Configure Vagaro booking providers

### DIFF
--- a/app/api/saunas/availability/route.ts
+++ b/app/api/saunas/availability/route.ts
@@ -1390,6 +1390,157 @@ async function fetchVagaroAvailability(
   return results;
 }
 
+interface VagaroClassEvent {
+  className: string;
+  availableTime: string;
+  availableEndTime: string;
+  strStartTime: string;
+  duration: number;
+  noOfAttendees: number;
+  eventCapacity: number;
+  sessionDetail: string; // "serviceId-qty-price-discount-finalPrice-tax"
+}
+
+async function fetchVagaroClassAvailability(
+  provider: VagaroBookingProviderConfig,
+  startDate: string
+): Promise<AppointmentTypeAvailability[]> {
+  const from = new Date(startDate);
+
+  // Build 7 days of dates in "Ddd Mmm-DD-YYYY" format
+  const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const monthNames = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+
+  const dates: { formatted: string; isoDate: string }[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(from);
+    d.setDate(d.getDate() + i);
+    const dayName = dayNames[d.getDay()];
+    const monthName = monthNames[d.getMonth()];
+    const dd = String(d.getDate()).padStart(2, "0");
+    const yyyy = d.getFullYear();
+    dates.push({
+      formatted: `${dayName} ${monthName}-${dd}-${yyyy}`,
+      isoDate: d.toISOString().split("T")[0],
+    });
+  }
+
+  // Service IDs we care about (filter out non-sauna classes)
+  const serviceIdSet = new Set(provider.services.map((s) => s.serviceId));
+
+  // Fetch each day in parallel
+  const dayResults = await Promise.all(
+    dates.map(async ({ formatted, isoDate }) => {
+      const res = await fetch(
+        `https://www.vagaro.com/${provider.region}/websiteapi/homepage/getavailablemultievents`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "User-Agent": VAGARO_USER_AGENT,
+            grouptoken: provider.region.toUpperCase(),
+          },
+          body: JSON.stringify({
+            businessID: provider.businessId,
+            sSatrtDate: formatted,
+            sEndDate: formatted,
+            Bus_TimeZone: -8,
+            Bus_CountryID: 1,
+            Bus_DayLightSaving: true,
+            DAY_LIGHT_SAVING: "Y",
+            Cust_Timezone: -8,
+            Cust_CountryID: "1",
+            Cust_IsDayLightSaving: true,
+            searchdetails:
+              "<searchdetails><searchdetail><serviceid>-2</serviceid><spid>-2</spid><streamingstatus>2</streamingstatus></searchdetail></searchdetails>",
+            userID: "0",
+            promotionID: 0,
+            isFromOffline: false,
+            IsNewWebsiteBuilder: false,
+            IncludededClassId: "",
+            ExcludededClassId: "",
+            IsAllowAllLocation: false,
+          }),
+          next: { revalidate: 300 },
+        }
+      );
+
+      if (!res.ok) {
+        console.error(
+          `Vagaro class API returned ${res.status} for date ${formatted}`
+        );
+        return { isoDate, events: [] as VagaroClassEvent[] };
+      }
+
+      const events = (await res.json()) as VagaroClassEvent[];
+      return { isoDate, events };
+    })
+  );
+
+  // Group events by service ID, mapping to our configured services
+  const serviceMap = new Map<
+    number,
+    { svc: (typeof provider.services)[0]; dates: Record<string, AvailabilitySlot[]> }
+  >();
+
+  for (const svc of provider.services) {
+    serviceMap.set(svc.serviceId, { svc, dates: {} });
+  }
+
+  for (const { isoDate, events } of dayResults) {
+    for (const event of events) {
+      // Parse serviceId from sessionDetail ("serviceId-qty-price-...")
+      const sessionServiceId = parseInt(event.sessionDetail.split("-")[0], 10);
+      if (!serviceIdSet.has(sessionServiceId)) continue;
+
+      const entry = serviceMap.get(sessionServiceId);
+      if (!entry) continue;
+
+      const spotsAvailable = event.eventCapacity - event.noOfAttendees;
+      if (spotsAvailable <= 0) continue;
+
+      // Convert time to 24h format
+      const match = event.availableTime.match(/(\d+):(\d+)\s*(AM|PM)/i);
+      let hours = 0;
+      let minutes = 0;
+      if (match) {
+        hours = parseInt(match[1], 10);
+        minutes = parseInt(match[2], 10);
+        const period = match[3].toUpperCase();
+        if (period === "PM" && hours !== 12) hours += 12;
+        if (period === "AM" && hours === 12) hours = 0;
+      }
+
+      if (!entry.dates[isoDate]) entry.dates[isoDate] = [];
+      entry.dates[isoDate].push({
+        time: `${isoDate} ${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:00`,
+        slotsAvailable: spotsAvailable,
+      });
+    }
+  }
+
+  return Array.from(serviceMap.values()).map(({ svc, dates }) => ({
+    appointmentTypeId: String(svc.serviceId),
+    name: svc.name,
+    price: svc.price,
+    durationMinutes: svc.durationMinutes,
+    dates,
+  }));
+}
+
 // --- Checkfront types (rate API response shapes) ---
 
 interface CheckfrontTimeslot {
@@ -2461,7 +2612,9 @@ export async function GET(request: NextRequest) {
         appointmentTypes = await fetchTrybeAvailability(provider, startDate);
         break;
       case "vagaro":
-        appointmentTypes = await fetchVagaroAvailability(provider, startDate);
+        appointmentTypes = provider.isClassBased
+          ? await fetchVagaroClassAvailability(provider, startDate)
+          : await fetchVagaroAvailability(provider, startDate);
         break;
       case "checkfront":
         appointmentTypes = await fetchCheckfrontAvailability(

--- a/data/saunas/saunas.ts
+++ b/data/saunas/saunas.ts
@@ -529,6 +529,8 @@ export interface VagaroBookingProviderConfig {
   region: string;
   /** IANA timezone for availability display */
   timezone: string;
+  /** If true, uses the classes/events API instead of the appointments API */
+  isClassBased?: boolean;
   /** Services to fetch availability for */
   services: {
     serviceId: number;
@@ -855,6 +857,27 @@ export const saunas: Sauna[] = [
     website: "https://www.815refresh.com/",
     bookingUrl: "https://www.vagaro.com/815refresh/book-now",
     bookingPlatform: "vagaro",
+    bookingProvider: {
+      type: "vagaro",
+      businessSlug: "815refresh",
+      businessId: "404046",
+      region: "us02",
+      timezone: "America/Los_Angeles",
+      services: [
+        {
+          serviceId: 36320697,
+          name: "1 hr Sauna Session",
+          price: 35,
+          durationMinutes: 60,
+        },
+        {
+          serviceId: 36320768,
+          name: "2 hr Sauna Session",
+          price: 50,
+          durationMinutes: 120,
+        },
+      ],
+    },
     sessionPrice: 25,
     sessionLengthMinutes: 60,
     steamRoom: false,
@@ -3253,6 +3276,28 @@ export const saunas: Sauna[] = [
     website: "https://snowpeakcampfield.com/ofuro/",
     bookingUrl: "https://www.vagaro.com/spcpyc3/classes",
     bookingPlatform: "vagaro",
+    bookingProvider: {
+      type: "vagaro",
+      businessSlug: "spcpyc3",
+      businessId: "375772",
+      region: "us05",
+      timezone: "America/Los_Angeles",
+      isClassBased: true,
+      services: [
+        {
+          serviceId: 13880,
+          name: "Ofuro Spa Day Guest Pass",
+          price: 35,
+          durationMinutes: 120,
+        },
+        {
+          serviceId: 68079,
+          name: "Ofuro Day Guest Adults Only",
+          price: 35,
+          durationMinutes: 120,
+        },
+      ],
+    },
     googleMapsUrl: "https://maps.app.goo.gl/XDiU6yWXPVXeaHf76",
     sessionPrice: 35, // Day guest pass; included for overnight guests
     sessionLengthMinutes: 120,


### PR DESCRIPTION
## Summary
- Added live availability for 815 Refresh (Seattle) and Snow Peak Campfield (Long Beach, WA)
- Snow Peak uses Vagaro's class-based API, so added fetchVagaroClassAvailability handler alongside the existing appointment API
- isClassBased flag routes each provider to the correct fetcher

## Test plan
- Availability appears for both saunas when viewing details
- 815 Refresh shows 1hr and 2hr session options
- Snow Peak shows Ofuro guest passes with real-time spot availability

🤖 Generated with Claude Code