### PR TITLE
Move Sauna Map to 2nd position in Tools menu

### DIFF
--- a/components/root-layout.tsx
+++ b/components/root-layout.tsx
@@ -45,6 +45,11 @@ export default async function RootLayout({
               </Link>
             </DropdownMenuItem>
             <DropdownMenuItem asChild>
+              <Link href="/tools/saunas">
+                Sauna Map
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
               <Link href="/tools/current-map">
                 PNW Current Map
               </Link>
@@ -57,11 +62,6 @@ export default async function RootLayout({
             <DropdownMenuItem asChild>
               <Link href="/tools/marriage-tax-calculator">
                 Marriage Tax Calculator
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link href="/tools/saunas">
-                Sauna Map
               </Link>
             </DropdownMenuItem>
             <DropdownMenuItem asChild>


### PR DESCRIPTION
Reorder the Tools menu to feature Sauna Map as the second option (after Discover EVs).

This improves discoverability of the Sauna Map tool in the main navigation menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)