### PR TITLE
Add Google Maps link for SoJo Spa Club

### DIFF
--- a/data/saunas/saunas.ts
+++ b/data/saunas/saunas.ts
@@ -5599,6 +5599,7 @@ export const saunas: Sauna[] = [
     website: "https://sojospaclub.com/",
     bookingUrl: "https://shop.sojospaclub.com/reservation/admission",
     bookingPlatform: "sojo",
+    googleMapsUrl: "https://maps.app.goo.gl/XU2bkRWjJVYUjbmeA",
     sessionPrice: 90,
     sessionLengthMinutes: null,
     steamRoom: false,


### PR DESCRIPTION
## Summary
- Adds missing Google Maps short link for SoJo Spa Club

🤖 Generated with [Claude Code](https://claude.com/claude-code)