### PR TITLE
Reset tide highlight when availability day changes

### DIFF
--- a/app/tools/saunas/components/SaunaDetailPanel.tsx
+++ b/app/tools/saunas/components/SaunaDetailPanel.tsx
@@ -67,6 +67,12 @@ export function SaunaDetailPanel({ sauna, availabilityDate, onAvailabilityDateCh
     setTideHighlightColor(null);
   }, [sauna.slug]);
 
+  // Reset tide highlight when the availability date changes
+  useEffect(() => {
+    setTideHighlightTime(null);
+    setTideHighlightColor(null);
+  }, [availabilityDate]);
+
   const handleHasAvailability = useCallback((v: boolean) => setHasAvailability(v), []);
   const handleFirstAvailableDate = useCallback((d: string | null) => setFirstAvailableDate(d), []);
   const handleLastAvailableDate = useCallback((d: string | null) => setLastAvailableDate(d), []);


### PR DESCRIPTION
When the user selects a different availability day in the detail view, the previously selected tide indicator is now cleared.

This provides a cleaner UX by ensuring the tide chart doesn't show stale highlights when viewing a new day's availability.

## Changes
- Added a new useEffect in SaunaDetailPanel that resets `tideHighlightTime` and `tideHighlightColor` whenever `availabilityDate` changes