### PR TITLE
Update Whidbey sauna water temp to Port Townsend station

### DIFF
--- a/data/saunas/saunas.ts
+++ b/data/saunas/saunas.ts
@@ -5540,8 +5540,8 @@ export const saunas: Sauna[] = [
     noaaTideStation: "9447855",
     waterTempProvider: {
       type: "noaa",
-      stationId: "9447130",
-      fallbackStationIds: ["9446484"],
+      stationId: "9444900",
+      fallbackStationIds: ["9447130", "9446484"],
     },
     showers: false,
     towelsIncluded: false,
@@ -5611,8 +5611,8 @@ export const saunas: Sauna[] = [
     noaaTideStation: "9447905",
     waterTempProvider: {
       type: "noaa",
-      stationId: "9447130",
-      fallbackStationIds: ["9446484"],
+      stationId: "9444900",
+      fallbackStationIds: ["9447130", "9446484"],
     },
     showers: false,
     towelsIncluded: false, // Bring two towels


### PR DESCRIPTION
Use Port Townsend (9444900) as primary NOAA station for water temperature on Driftwood and Good Medicine Whidbey saunas. Port Townsend is across Admiralty Inlet and more representative of actual plunge conditions than Seattle.

Updates fallback chain to include Seattle as secondary fallback.