### PR TITLE
Add Beach Sauna Express listing with Sweatpals integration

### DIFF
--- a/app/api/saunas/availability/route.ts
+++ b/app/api/saunas/availability/route.ts
@@ -24,6 +24,7 @@ import {
   type BoulevardBookingProviderConfig,
   type ArketaBookingProviderConfig,
   type SojoBookingProviderConfig,
+  type SweatpalsBookingProviderConfig,
 } from "@/data/saunas/saunas";
 
 export interface AvailabilitySlot {
@@ -2887,6 +2888,12 @@ export async function GET(request: NextRequest) {
       case "sojo":
         appointmentTypes = await fetchSojoAvailability(provider, startDate);
         break;
+      case "sweatpals":
+        appointmentTypes = await fetchSweatpalsAvailability(
+          provider,
+          startDate
+        );
+        break;
     }
 
     return Response.json({ appointmentTypes } satisfies AvailabilityResponse);
@@ -2897,4 +2904,115 @@ export async function GET(request: NextRequest) {
       { status: 502 }
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Sweatpals
+// ---------------------------------------------------------------------------
+
+interface SweatpalsEvent {
+  id: string;
+  baseId: string;
+  name: string;
+  instance: string;
+  instanceEndDate: string;
+  shortLocalInstance: string;
+  eventInstanceId: string;
+  addressName: string;
+  addressLat: number;
+  addressLng: number;
+  isPaid: boolean;
+  tzid: string;
+  attendeesLimit: number | null;
+  participantsCount: number;
+  prices: {
+    priceAmount: number;
+    currency: string;
+    tierName: string;
+    basePriceId: string;
+    maxTickets: number | null;
+  }[];
+}
+
+async function fetchSweatpalsAvailability(
+  provider: SweatpalsBookingProviderConfig,
+  startDate: string
+): Promise<AppointmentTypeAvailability[]> {
+  const from = new Date(startDate);
+  const to = new Date(from);
+  to.setDate(to.getDate() + 6);
+
+  const res = await fetch(
+    "https://ilove.sweatpals.com/api/events/public/search",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        limit: 20,
+        onlyBusinessAuthors: false,
+        withEventTypes: ["EVENT", "CLASS", "RETREAT"],
+        creatorsIds: [provider.creatorId],
+        withUnverifiedEvents: true,
+        sort: "instance",
+        periodFrom: `${startDate}T00:00:00.000Z`,
+        periodTo: `${to.toISOString().split("T")[0]}T23:59:59.000Z`,
+      }),
+      next: { revalidate: 300 },
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(`Sweatpals API returned ${res.status}`);
+  }
+
+  const events: SweatpalsEvent[] = await res.json();
+
+  // Build a set of base IDs we care about
+  const trackedBaseIds = new Set(provider.events.map((e) => e.baseEventId));
+
+  // Group matching event instances by baseId → date → slots
+  const byBase = new Map<string, Record<string, AvailabilitySlot[]>>();
+
+  for (const ev of events) {
+    if (!trackedBaseIds.has(ev.baseId)) continue;
+
+    // Convert UTC instance to local date in provider timezone
+    const localDate = new Date(ev.instance).toLocaleDateString("en-CA", {
+      timeZone: provider.timezone,
+    }); // "YYYY-MM-DD"
+
+    const localTime = new Date(ev.instance).toLocaleString("sv-SE", {
+      timeZone: provider.timezone,
+    }); // "YYYY-MM-DD HH:mm:ss"
+
+    if (!byBase.has(ev.baseId)) {
+      byBase.set(ev.baseId, {});
+    }
+    const dates = byBase.get(ev.baseId)!;
+    if (!dates[localDate]) {
+      dates[localDate] = [];
+    }
+
+    // Compute remaining spots
+    const limit = ev.attendeesLimit;
+    const slotsAvailable =
+      limit != null && limit < Number.MAX_SAFE_INTEGER
+        ? Math.max(0, limit - ev.participantsCount)
+        : null;
+
+    dates[localDate].push({
+      time: localTime,
+      slotsAvailable,
+    });
+  }
+
+  return provider.events
+    .filter((evt) => byBase.has(evt.baseEventId))
+    .map((evt) => ({
+      appointmentTypeId: evt.baseEventId,
+      name: evt.name,
+      price: evt.price,
+      durationMinutes: evt.durationMinutes,
+      dates: byBase.get(evt.baseEventId) ?? {},
+    }));
 }

--- a/data/saunas/saunas.ts
+++ b/data/saunas/saunas.ts
@@ -32,7 +32,8 @@ export type LocationSlug =
   | "greenville"
   | "knoxville"
   | "bonita-springs"
-  | "austin";
+  | "austin"
+  | "san-diego";
 
 /**
  * Location metadata for display and routing
@@ -325,6 +326,15 @@ export const locations: Location[] = [
       "Austin's sauna scene features Nordic-inspired bathhouses with traditional saunas, cold plunges, and integrative wellness in the heart of Texas.",
     center: { lat: 30.3248, lng: -97.738 },
     zoom: 12,
+  },
+  {
+    slug: "san-diego",
+    name: "San Diego",
+    state: "CA",
+    description:
+      "San Diego's sauna scene brings wood-fired mobile saunas to the beach, pairing traditional heat with cold plunges in the Pacific Ocean.",
+    center: { lat: 33.085, lng: -117.312 },
+    zoom: 11,
   },
 ];
 
@@ -821,6 +831,26 @@ export interface SojoBookingProviderConfig {
 }
 
 /**
+ * Sweatpals event platform booking provider configuration.
+ * Uses the public events search API to find upcoming event instances.
+ */
+export interface SweatpalsBookingProviderConfig {
+  type: "sweatpals";
+  /** Sweatpals host/creator user ID (UUID) */
+  creatorId: string;
+  /** IANA timezone for availability display */
+  timezone: string;
+  /** Events to show availability for */
+  events: {
+    /** Base event ID (UUID) — identifies the recurring series */
+    baseEventId: string;
+    name: string;
+    price: number;
+    durationMinutes: number;
+  }[];
+}
+
+/**
  * Booking provider configuration for availability checking.
  * Uses a discriminated union so new providers can be added
  * by extending this type.
@@ -847,7 +877,8 @@ export type BookingProviderConfig =
   | RollerBookingProviderConfig
   | BoulevardBookingProviderConfig
   | ArketaBookingProviderConfig
-  | SojoBookingProviderConfig;
+  | SojoBookingProviderConfig
+  | SweatpalsBookingProviderConfig;
 
 // --- Water Temperature Provider Types ---
 
@@ -939,7 +970,8 @@ export interface Sauna {
     | "fresha"
     | "envision"
     | "arketa"
-    | "sojo";
+    | "sojo"
+    | "sweatpals";
   /**
    * Google Maps short link. Use the maps.app.goo.gl format.
    * @example "https://maps.app.goo.gl/FQ1MFyyV8vXXAhnF8"
@@ -3803,6 +3835,50 @@ export const saunas: Sauna[] = [
     lat: 44.7817,
     lng: -121.9778,
     updatedAt: "2026-01-05",
+  },
+  // ============================================================================
+  // SAN DIEGO, CA
+  // ============================================================================
+  {
+    slug: "beach-sauna-express",
+    name: "Beach Sauna Express",
+    address: "South Ponto Beach, 9969 Carlsbad Blvd, Encinitas, CA 92024",
+    website: "https://www.beachsaunaexpress.com",
+    bookingUrl:
+      "https://sweatpals.com/event/beach-sauna-sunday-detox-awaken-your-energy-naturally-a2",
+    googleMapsUrl: "https://maps.app.goo.gl/Xus1SLWsgmWsf8qDA",
+    sessionPrice: 70,
+    sessionLengthMinutes: 360,
+    steamRoom: false,
+    coldPlunge: true,
+    soakingTub: false,
+    waterfront: true,
+    naturalPlunge: true,
+    showers: false,
+    towelsIncluded: false,
+    temperatureRangeF: { min: 170, max: 200 },
+    hours: "Sundays 3pm-9pm (check Sweatpals for schedule)",
+    genderPolicy: "Co-ed",
+    clothingPolicy: "Swimsuit required",
+    notes:
+      "Wood-fired mobile sauna on South Ponto Beach. Includes unlimited sauna access, Venik Platza rituals with eucalyptus branches, cold plunge in the Pacific Ocean, and tea service. Recurring weekly Sunday sessions booked through Sweatpals.",
+    lat: 33.085,
+    lng: -117.3117,
+    updatedAt: "2026-03-01",
+    bookingPlatform: "sweatpals",
+    bookingProvider: {
+      type: "sweatpals",
+      creatorId: "749852f8-7b60-48e6-a05f-70a049fc1a96",
+      timezone: "America/Los_Angeles",
+      events: [
+        {
+          baseEventId: "74f4bdb6-f860-42bc-a1f9-319a4192ca28",
+          name: "Beach Sauna Sunday",
+          price: 70,
+          durationMinutes: 360,
+        },
+      ],
+    },
   },
   // ============================================================================
   // VANCOUVER, BC, CANADA


### PR DESCRIPTION
## Summary

Added Beach Sauna Express (South Ponto Beach, Encinitas, CA) with live availability via a new Sweatpals booking provider.

- Implemented `SweatpalsBookingProviderConfig` type and `fetchSweatpalsAvailability()` using the public events API
- Added "san-diego" location slug
- Tracks the recurring $70 Beach Sauna Sunday series (every Sunday 3–9 PM)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>