### PR TITLE
Extract shared Navbar component

### DIFF
--- a/app/tools/saunas/layout.tsx
+++ b/app/tools/saunas/layout.tsx
@@ -1,10 +1,4 @@
-import Link from "next/link";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import Navbar from "@/components/navbar";
 
 export default function SaunasLayout({
   children,
@@ -16,50 +10,7 @@ export default function SaunasLayout({
       {/* Header - constrained width - hidden on mobile */}
       <header className="hidden lg:block border-b shrink-0">
         <div className="max-w-2xl mx-auto py-4 px-4 flex flex-col gap-4 items-center">
-          <Link className="text-3xl" href="/">
-            {`Gabe O'Leary`}
-          </Link>
-          <nav>
-            <ul className="text-blue-600 flex gap-5 items-center justify-center">
-              <li>
-                <Link className="hover:text-blue-500" href="/about">
-                  About
-                </Link>
-              </li>
-              <li>
-                <Link className="hover:text-blue-500" href="/posts">
-                  Posts
-                </Link>
-              </li>
-              <li>
-                <Link className="hover:text-blue-500" href="/travel">
-                  Travel
-                </Link>
-              </li>
-              <DropdownMenu>
-                <DropdownMenuTrigger>Tools</DropdownMenuTrigger>
-                <DropdownMenuContent>
-                  <DropdownMenuItem>
-                    <Link href="https://discoverevs.com">Discover EVs</Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem>
-                    <Link href="/tools/current-map">PNW Current Map</Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem>
-                    <Link href="/tools/lake-stats">Seattle Lake Stats</Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem>
-                    <Link href="/tools/marriage-tax-calculator">
-                      Marriage Tax Calculator
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem>
-                    <Link href="/tools/saunas">Sauna Map</Link>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </ul>
-          </nav>
+          <Navbar />
         </div>
       </header>
 
@@ -68,4 +19,3 @@ export default function SaunasLayout({
     </div>
   );
 }
-

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import { isAuthenticated } from "@/lib/auth";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+
+export default async function Navbar() {
+  const loggedIn = await isAuthenticated();
+  return (
+    <>
+      <Link className="text-3xl" href="/">
+        {`Gabe O'Leary`}
+      </Link>
+
+      <ul className="text-blue-600 flex gap-5 m-auto items-center justify-center md:flex-row">
+        <li>
+          <Link className="hover:text-blue-500" href="/about">
+            About
+          </Link>
+        </li>
+        <li>
+          <Link className="hover:text-blue-500" href="/posts">
+            Posts
+          </Link>
+        </li>
+        <li>
+          <Link className="hover:text-blue-500" href="/travel">
+            Travel
+          </Link>
+        </li>
+        <DropdownMenu>
+          <DropdownMenuTrigger>Tools</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem asChild>
+              <Link href="https://discoverevs.com">
+                Discover EVs
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/tools/saunas">
+                Sauna Map
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/tools/current-map">
+                PNW Current Map
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/tools/lake-stats">
+                Seattle Lake Stats
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/tools/marriage-tax-calculator">
+                Marriage Tax Calculator
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/tools/seattle-transit">
+                Seattle Transit
+              </Link>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {(process.env.NODE_ENV === "development" || loggedIn) && (
+          <DropdownMenu>
+            <DropdownMenuTrigger>Debug</DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem asChild>
+                <Link href="/tools/debug-saunas">Saunas</Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/tools/debug-icons">Icons</Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/tools/debug-seo">SEO</Link>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </ul>
+    </>
+  );
+}

--- a/components/root-layout.tsx
+++ b/components/root-layout.tsx
@@ -1,93 +1,13 @@
-import Link from "next/link";
-import { isAuthenticated } from "@/lib/auth";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "./ui/dropdown-menu";
+import Navbar from "./navbar";
 
 export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const loggedIn = await isAuthenticated();
-  // Create any shared layout or styles here
   return (
     <div className="max-w-2xl m-auto text-md py-6 flex flex-col gap-4 items-center">
-      <Link className="text-3xl" href="/">
-        {`Gabe O'Leary`}
-      </Link>
-
-      <ul className="text-blue-600 flex  gap-5 m-auto items-center justify-center md:flex-row">
-        <li>
-          <Link className="hover:text-blue-500" href="/about">
-            About
-          </Link>
-        </li>
-        <li>
-          <Link className="hover:text-blue-500" href="/posts">
-            Posts
-          </Link>
-        </li>
-        <li>
-          <Link className="hover:text-blue-500" href="/travel">
-            Travel
-          </Link>
-        </li>
-        <DropdownMenu>
-          <DropdownMenuTrigger>Tools</DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem asChild>
-              <Link href="https://discoverevs.com">
-                Discover EVs
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link href="/tools/saunas">
-                Sauna Map
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link href="/tools/current-map">
-                PNW Current Map
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link href="/tools/lake-stats">
-                Seattle Lake Stats
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link href="/tools/marriage-tax-calculator">
-                Marriage Tax Calculator
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link href="/tools/seattle-transit">
-                Seattle Transit
-              </Link>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-        {(process.env.NODE_ENV === "development" || loggedIn) && (
-          <DropdownMenu>
-            <DropdownMenuTrigger>Debug</DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuItem asChild>
-                <Link href="/tools/debug-saunas">Saunas</Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <Link href="/tools/debug-icons">Icons</Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <Link href="/tools/debug-seo">SEO</Link>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
-      </ul>
+      <Navbar />
       <div className="w-full px-4 md:px-0">{children}</div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Extracts the duplicated navbar into a shared `components/navbar.tsx` component
- Replaces the stale copy in the sauna map layout (`app/tools/saunas/layout.tsx`) which was missing Seattle Transit, Debug menu, and `asChild` props on dropdown items
- Updates `components/root-layout.tsx` to use the same shared component

## Test plan
- [ ] Verify navbar renders correctly on standard pages (About, Posts, Travel, etc.)
- [ ] Verify navbar renders correctly on the sauna map (desktop — hidden on mobile)
- [ ] Verify Tools and Debug dropdowns work in both contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)