### PR TITLE
Fix tide indicator flickering on availability pills

### DIFF
--- a/app/tools/saunas/components/SaunaAvailability.tsx
+++ b/app/tools/saunas/components/SaunaAvailability.tsx
@@ -187,7 +187,6 @@ export function SaunaAvailability({ sauna, availabilityDate, onAvailabilityDateC
       })
       .then((json: AvailabilityResponse) => {
         setData(json);
-        setTideDataByDate({});
         setLoading(false);
         setRefreshing(false);
       })


### PR DESCRIPTION
## Summary
Fixed flickering of tide indicators on availability pills in the sauna detail view. The issue was caused by clearing tide data every time availability refreshed, making pills briefly render without indicators while new tide data fetched.

## Changes
Removed the `setTideDataByDate({})` call when refreshing availability data for the same sauna. The tide data effect already replaces the entire map, so preserving existing data prevents the flash.

## Testing
- Select different dates on a sauna detail page
- Verify tide indicators remain visible and don't flicker after selection

🤖 Generated with Claude Code