### PR TITLE
Improve current map mobile layout

### DIFF
--- a/app/tools/current-map/components/Controls.tsx
+++ b/app/tools/current-map/components/Controls.tsx
@@ -60,8 +60,8 @@ const Controls: React.FC<ControlsProps> = ({
   }, [dates.length, isPlaying, setSliderValue]);
 
   return (
-    <div className="absolute bottom-10 left-0 right-0 z-[400] mx-auto w-[80%] rounded-lg border bg-background/95 backdrop-blur-sm shadow-lg p-3 flex flex-col gap-2">
-      <div className="flex items-center gap-2">
+    <div className="absolute bottom-4 sm:bottom-10 left-0 right-0 z-[400] mx-auto w-[92%] sm:w-[80%] rounded-lg border bg-background/95 backdrop-blur-sm shadow-lg p-2 sm:p-3 flex flex-col gap-1.5 sm:gap-2">
+      <div className="flex items-center gap-2 flex-wrap">
         <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
           <PopoverTrigger asChild>
             <Button
@@ -87,7 +87,7 @@ const Controls: React.FC<ControlsProps> = ({
             />
           </PopoverContent>
         </Popover>
-        <span className="text-sm text-muted-foreground">
+        <span className="text-xs sm:text-sm text-muted-foreground truncate min-w-0">
           {dates[sliderValue]
             ? dateFormat(dates[sliderValue], "ddd, mmm dS, h:MM TT")
             : ""}
@@ -95,38 +95,6 @@ const Controls: React.FC<ControlsProps> = ({
         {loading && (
           <Loader2 className="size-3.5 animate-spin text-muted-foreground shrink-0" />
         )}
-        <div className="flex items-center gap-3 ml-auto shrink-0">
-          <div className="flex items-center gap-1.5">
-            <Checkbox
-              id="show-currents"
-              checked={showCurrents}
-              onCheckedChange={(v) => onShowCurrentsChange(v === true)}
-            />
-            <Label htmlFor="show-currents" className="text-xs cursor-pointer">
-              Currents
-            </Label>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <Checkbox
-              id="show-tides"
-              checked={showTides}
-              onCheckedChange={(v) => onShowTidesChange(v === true)}
-            />
-            <Label htmlFor="show-tides" className="text-xs cursor-pointer">
-              Tides
-            </Label>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <Checkbox
-              id="show-water-temp"
-              checked={showWaterTemp}
-              onCheckedChange={(v) => onShowWaterTempChange(v === true)}
-            />
-            <Label htmlFor="show-water-temp" className="text-xs cursor-pointer">
-              Current Water Temp
-            </Label>
-          </div>
-        </div>
       </div>
       <div className="flex items-center gap-2">
         <Button
@@ -148,6 +116,38 @@ const Controls: React.FC<ControlsProps> = ({
           onValueChange={([val]) => setSliderValue(val)}
           className="flex-1"
         />
+      </div>
+      <div className="flex items-center gap-3 border-t pt-1.5 sm:pt-0 sm:border-t-0">
+        <div className="flex items-center gap-1.5">
+          <Checkbox
+            id="show-currents"
+            checked={showCurrents}
+            onCheckedChange={(v) => onShowCurrentsChange(v === true)}
+          />
+          <Label htmlFor="show-currents" className="text-xs cursor-pointer">
+            Currents
+          </Label>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Checkbox
+            id="show-tides"
+            checked={showTides}
+            onCheckedChange={(v) => onShowTidesChange(v === true)}
+          />
+          <Label htmlFor="show-tides" className="text-xs cursor-pointer">
+            Tides
+          </Label>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Checkbox
+            id="show-water-temp"
+            checked={showWaterTemp}
+            onCheckedChange={(v) => onShowWaterTempChange(v === true)}
+          />
+          <Label htmlFor="show-water-temp" className="text-xs cursor-pointer">
+            Current Water Temp
+          </Label>
+        </div>
       </div>
     </div>
   );

--- a/app/tools/current-map/components/Legend.tsx
+++ b/app/tools/current-map/components/Legend.tsx
@@ -1,133 +1,102 @@
 import React from "react";
+import { InfoIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 
 export const LEGEND_COLORS = ["#0d0887", "#7e03a8", "#cc4778", "#f89540"];
 export const VELOCITY_BREAK_POINTS = [0, 1, 3, 5];
 
-const Legend: React.FC = () => {
-  return (
-    <div
-      style={{
-        position: "absolute",
-        margin: "auto",
-        top: "20vh",
-        right: 24,
-        zIndex: 400,
-        padding: 8,
-        border: "1px solid gray",
-        backgroundColor: "white",
-        borderRadius: 8,
-        display: "flex",
-        flexDirection: "column",
-        maxWidth: 140,
-      }}
-    >
-      <div style={{ fontSize: 14, padding: "8px 0 4px", textAlign: "center", fontWeight: "bold" }}>
-        Current speed
-      </div>
-      {LEGEND_COLORS.map((color, i) => (
+const LegendContent: React.FC = () => (
+  <div className="flex flex-col text-xs">
+    <div className="text-sm font-bold text-center pb-1">Current speed</div>
+    {LEGEND_COLORS.map((color, i) => (
+      <div className="flex items-center gap-2 py-px" key={`current-${i}`}>
         <div
-          style={{
-            display: "flex",
-            flexDirection: "row",
-            alignItems: "center",
-            fontSize: 12,
-          }}
-          key={`current-${i}`}
-        >
-          <div
-            style={{
-              backgroundColor: color,
-              width: 12,
-              height: 12,
-              marginRight: 8,
-            }}
-          ></div>
+          className="w-3 h-3 shrink-0"
+          style={{ backgroundColor: color }}
+        />
+        <span>
           {i < LEGEND_COLORS.length - 1
             ? `${VELOCITY_BREAK_POINTS[i]}-${VELOCITY_BREAK_POINTS[i + 1]}`
-            : `${VELOCITY_BREAK_POINTS[i]}+ `}
-          {` knots`}
-        </div>
-      ))}
-      <div
-        style={{
-          borderTop: "1px solid #ddd",
-          marginTop: 8,
-          paddingTop: 4,
-          fontSize: 14,
-          textAlign: "center",
-          fontWeight: "bold",
-        }}
-      >
-        Tide level
+            : `${VELOCITY_BREAK_POINTS[i]}+`}{" "}
+          knots
+        </span>
       </div>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          fontSize: 12,
-          gap: 8,
-          padding: "4px 0",
-        }}
-      >
-        <svg width="24" height="12" viewBox="0 0 24 12">
-          <circle cx="6" cy="6" r="5" fill="#d1e5f0" stroke="white" strokeWidth="1" />
-          <circle cx="18" cy="6" r="5" fill="#d1e5f0" stroke="white" strokeWidth="1" />
-          <clipPath id="legend-fill">
-            <rect x="13" y="0" width="10" height="12" />
-          </clipPath>
-          <circle cx="18" cy="6" r="5" fill="#2166ac" clipPath="url(#legend-fill)" />
-        </svg>
-        low — high
-      </div>
-      <div
-        style={{
-          borderTop: "1px solid #ddd",
-          marginTop: 8,
-          paddingTop: 4,
-          fontSize: 14,
-          textAlign: "center",
-          fontWeight: "bold",
-        }}
-      >
-        Water temp
-      </div>
-      {[
-        { color: "#3b82f6", label: "< 45°F" },
-        { color: "#0ea5e9", label: "45-50°F" },
-        { color: "#06b6d4", label: "50-55°F" },
-        { color: "#14b8a6", label: "55-60°F" },
-        { color: "#22c55e", label: "60-65°F" },
-        { color: "#eab308", label: "65-70°F" },
-        { color: "#f97316", label: "> 70°F" },
-      ].map(({ color, label }) => (
-        <div
-          key={label}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            fontSize: 12,
-            gap: 8,
-            padding: "1px 0",
-          }}
-        >
-          <div
-            style={{
-              backgroundColor: color,
-              width: 12,
-              height: 12,
-              borderRadius: "50%",
-            }}
-          />
-          {label}
-        </div>
-      ))}
-      <div style={{ fontSize: 12, padding: "8px 0 4px", textAlign: "center" }}>
-        built by{" "}
-        <a href="/" className="underline text-nowrap">
-          {"Gabe O'Leary"}
-        </a>
-      </div>
+    ))}
+    <div className="border-t border-gray-200 mt-2 pt-1 text-sm font-bold text-center">
+      Tide level
     </div>
+    <div className="flex items-center gap-2 py-1 text-xs">
+      <svg width="24" height="12" viewBox="0 0 24 12">
+        <circle cx="6" cy="6" r="5" fill="#d1e5f0" stroke="white" strokeWidth="1" />
+        <circle cx="18" cy="6" r="5" fill="#d1e5f0" stroke="white" strokeWidth="1" />
+        <clipPath id="legend-fill">
+          <rect x="13" y="0" width="10" height="12" />
+        </clipPath>
+        <circle cx="18" cy="6" r="5" fill="#2166ac" clipPath="url(#legend-fill)" />
+      </svg>
+      low — high
+    </div>
+    <div className="border-t border-gray-200 mt-2 pt-1 text-sm font-bold text-center">
+      Water temp
+    </div>
+    {[
+      { color: "#3b82f6", label: "< 45°F" },
+      { color: "#0ea5e9", label: "45-50°F" },
+      { color: "#06b6d4", label: "50-55°F" },
+      { color: "#14b8a6", label: "55-60°F" },
+      { color: "#22c55e", label: "60-65°F" },
+      { color: "#eab308", label: "65-70°F" },
+      { color: "#f97316", label: "> 70°F" },
+    ].map(({ color, label }) => (
+      <div key={label} className="flex items-center gap-2 py-px">
+        <div
+          className="w-3 h-3 rounded-full shrink-0"
+          style={{ backgroundColor: color }}
+        />
+        <span>{label}</span>
+      </div>
+    ))}
+    <div className="text-xs text-center pt-2">
+      built by{" "}
+      <a href="/" className="underline whitespace-nowrap">
+        {"Gabe O'Leary"}
+      </a>
+    </div>
+  </div>
+);
+
+const Legend: React.FC = () => {
+  return (
+    <>
+      {/* Mobile: popover button */}
+      <div className="md:hidden absolute top-3 right-12 z-[400] pointer-events-none [&>*]:pointer-events-auto">
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              className="size-8 bg-background/95 backdrop-blur-sm shadow-lg"
+            >
+              <InfoIcon className="size-4" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-40 p-2 z-[500]" align="end">
+            <LegendContent />
+          </PopoverContent>
+        </Popover>
+      </div>
+      {/* Desktop: always visible */}
+      <div className="hidden md:flex absolute top-[20vh] right-6 z-[400] p-2 border border-gray-400 bg-white rounded-lg max-w-[140px]">
+        <LegendContent />
+      </div>
+    </>
   );
 };
+
 export default Legend;

--- a/app/tools/current-map/components/Title.tsx
+++ b/app/tools/current-map/components/Title.tsx
@@ -2,26 +2,8 @@ import React from "react";
 
 const Title: React.FC = () => {
   return (
-    <div
-      style={{
-        position: "absolute",
-        margin: "auto",
-        display: "flex",
-        flexDirection: "column",
-        gap: 8,
-        top: 20,
-        left: 0,
-        right: 0,
-        zIndex: 400,
-        width: "fit-content",
-        padding: 8,
-        border: "1px solid gray",
-        backgroundColor: "white",
-        borderRadius: 8,
-        textAlign: "center",
-      }}
-    >
-      <div style={{ fontSize: 18, fontWeight: "bold" }}>
+    <div className="absolute top-3 left-0 right-0 z-[400] w-fit mx-auto px-2 py-1.5 sm:px-3 sm:py-2 border border-gray-400 bg-white rounded-lg text-center">
+      <div className="text-sm sm:text-lg font-bold">
         Salish Sea Current Map
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **Legend**: Collapses into an info icon popover on mobile (`< md`), stays always visible on desktop
- **Controls**: Stacks date/time, slider, and layer toggles into separate rows on mobile with tighter spacing
- **Title**: Smaller text and padding on mobile, scales up at `sm` breakpoint

## Test plan
- [ ] Open `/tools/current-map` on a mobile-width viewport and verify legend is a popover button
- [ ] Verify legend panel is always visible on desktop (`≥ md`)
- [ ] Verify controls panel layout stacks cleanly on small screens
- [ ] Verify title text is readable on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)